### PR TITLE
Edit utils to handle TimeDistributed

### DIFF
--- a/keras_adamw/__init__.py
+++ b/keras_adamw/__init__.py
@@ -1,3 +1,3 @@
 import os
 
-__version__ = '1.1'
+__version__ = '1.11'

--- a/keras_adamw/utils.py
+++ b/keras_adamw/utils.py
@@ -33,16 +33,18 @@ def fill_dict_in_order(_dict, _list_of_vals):
 
 
 def _get_layer_l2regs(layer):
-    if hasattr(layer, 'layer') or hasattr(layer, 'cell'):
+    if hasattr(layer, 'cell') or \
+      (hasattr(layer, 'layer') and hasattr(layer.layer, 'cell')):
         return _rnn_l2regs(layer)
-    else:
-        l2_lambda_kb = []
-        for weight_name in ['kernel', 'bias']:
-            _lambda = getattr(layer, weight_name + '_regularizer', None)
-            if _lambda is not None:
-                l2_lambda_kb.append([getattr(layer, weight_name).name,
-                                     float(_lambda.l2)])
-        return l2_lambda_kb
+    elif hasattr(layer, 'layer') and not hasattr(layer.layer, 'cell'):
+        layer = layer.layer
+    l2_lambda_kb = []
+    for weight_name in ['kernel', 'bias']:
+        _lambda = getattr(layer, weight_name + '_regularizer', None)
+        if _lambda is not None:
+            l2_lambda_kb.append([getattr(layer, weight_name).name,
+                                 float(_lambda.l2)])
+    return l2_lambda_kb
 
 
 def _rnn_l2regs(layer):

--- a/keras_adamw/utils_225tf.py
+++ b/keras_adamw/utils_225tf.py
@@ -34,16 +34,18 @@ def fill_dict_in_order(_dict, _list_of_vals):
 
 
 def _get_layer_l2regs(layer):
-    if hasattr(layer, 'layer') or hasattr(layer, 'cell'):
+    if hasattr(layer, 'cell') or \
+      (hasattr(layer, 'layer') and hasattr(layer.layer, 'cell')):
         return _rnn_l2regs(layer)
-    else:
-        l2_lambda_kb = []
-        for weight_name in ['kernel', 'bias']:
-            _lambda = getattr(layer, weight_name + '_regularizer', None)
-            if _lambda is not None:
-                l2_lambda_kb.append([getattr(layer, weight_name).name,
-                                     float(_lambda.l2)])
-        return l2_lambda_kb
+    elif hasattr(layer, 'layer') and not hasattr(layer.layer, 'cell'):
+        layer = layer.layer
+    l2_lambda_kb = []
+    for weight_name in ['kernel', 'bias']:
+        _lambda = getattr(layer, weight_name + '_regularizer', None)
+        if _lambda is not None:
+            l2_lambda_kb.append([getattr(layer, weight_name).name,
+                                 float(_lambda.l2)])
+    return l2_lambda_kb
 
 
 def _rnn_l2regs(layer):


### PR DESCRIPTION
_utils.py_ and _utils_225tf.py_ wouldn't properly handle the `TimeDistributed` layer wrapper - now they will.

Updated version to 1.11