### PR TITLE
Fix `get_weight_decays` for Bi-RNNs

### DIFF
--- a/keras_adamw/__init__.py
+++ b/keras_adamw/__init__.py
@@ -1,3 +1,3 @@
 import os
 
-__version__ = '1.12'
+__version__ = '1.13'

--- a/keras_adamw/utils.py
+++ b/keras_adamw/utils.py
@@ -61,15 +61,11 @@ def _cell_l2regs(rnn_cell):
     cell = rnn_cell
     l2_lambda_krb = []  # kernel-recurrent-bias
 
-    if hasattr(cell, 'kernel_regularizer') or \
-       hasattr(cell, 'recurrent_regularizer') or hasattr(cell, 'bias_regularizer'):
-        for weight_name in ['kernel', 'recurrent', 'bias']:
-            _lambda = getattr(cell, weight_name + '_regularizer', None)
-            if _lambda is not None:
-                weight_name = weight_name if 'recurrent' not in weight_name \
-                                          else 'recurrent_kernel'
-                l2_lambda_krb.append([getattr(cell, weight_name).name,
-                                      float(_lambda.l2)])
+    for weight_idx, weight_type in enumerate(['kernel', 'recurrent', 'bias']):
+        _lambda = getattr(cell, weight_type + '_regularizer', None)
+        if _lambda is not None:
+            weight_name = cell.weights[weight_idx].name
+            l2_lambda_krb.append([weight_name, float(_lambda.l2)])
     return l2_lambda_krb
 
 

--- a/keras_adamw/utils_225tf.py
+++ b/keras_adamw/utils_225tf.py
@@ -62,15 +62,11 @@ def _cell_l2regs(rnn_cell):
     cell = rnn_cell
     l2_lambda_krb = []  # kernel-recurrent-bias
 
-    if hasattr(cell, 'kernel_regularizer') or \
-       hasattr(cell, 'recurrent_regularizer') or hasattr(cell, 'bias_regularizer'):
-        for weight_name in ['kernel', 'recurrent', 'bias']:
-            _lambda = getattr(cell, weight_name + '_regularizer', None)
-            if _lambda is not None:
-                weight_name = weight_name if 'recurrent' not in weight_name \
-                                          else 'recurrent_kernel'
-                l2_lambda_krb.append([getattr(cell, weight_name).name,
-                                      float(_lambda.l2)])
+    for weight_idx, weight_type in enumerate(['kernel', 'recurrent', 'bias']):
+        _lambda = getattr(cell, weight_type + '_regularizer', None)
+        if _lambda is not None:
+            weight_name = cell.weights[weight_idx].name
+            l2_lambda_krb.append([weight_name, float(_lambda.l2)])
     return l2_lambda_krb
 
 


### PR DESCRIPTION
When `kernel_regularizer` and `recurrent_regularizer` were being set, `get_weight_decays` could fetch an irrelevant attribute for certain RNNs (e.g. IndRNN) -- fixed