### PR TITLE
v1.15: Automate imports, more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,16 @@ python:
   - "3.6"
 env:
   global:
-    - TF_PYTHON="False"
-    - TF_EAGER="False"
-    - TF_KERAS="False"
+    - TF_PYTHON="0"
+    - TF_EAGER="0"
+    - TF_KERAS="0"
   matrix:
     - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5"
-    - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5" TF_KERAS="True"
-    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_EAGER="True"
+    - TF_VERSION="1.14.0" KERAS_VERSION="2.2.5" TF_KERAS="1"
+    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_EAGER="1"
     - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0"
-    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_KERAS="True"  TF_EAGER="True"
-    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_KERAS="True"  
-#    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_PYTHON="True" TF_EAGER="True" -- succeeds locally per bug-fixed tf code
+    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_KERAS="1"  TF_EAGER="1"
+    - TF_VERSION="2.0.0"  KERAS_VERSION="2.3.0" TF_KERAS="1"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Not configured to be installed via `!pip` or `git pull`; simply clone or downloa
 
 ## Usage
 
+If using tensorflow.keras imports, set `import os; os.environ["TF_KERAS"]='1'`.
+
 ### Weight decay 
 `AdamW(.., weight_decays=weight_decays)`<br>
 Two methods to set `weight_decays = {<weight matrix name>:<weight decay value>,}`:
@@ -63,8 +65,7 @@ weight_decays.update({'conv1d_0/kernel:0':1e-4}) # example
 from keras.layers import Input, Dense, LSTM
 from keras.models import Model
 from keras.regularizers import l2
-from keras_adamw.optimizers import AdamW
-from keras_adamw.utils import get_weight_decays, fill_dict_in_order
+from keras_adamw import AdamW, get_weight_decays, fill_dict_in_order
 import numpy as np 
 
 ipt   = Input(shape=(120,4))

--- a/keras_adamw/README.md
+++ b/keras_adamw/README.md
@@ -1,4 +1,4 @@
-### Which optimizers to use?
+### Which files are used?
 
 ```python
 TensorFlow 1.14.0 + Keras 2.2.5 + 'keras'    >> optimizers_225.py   + utils.py
@@ -6,6 +6,9 @@ TensorFlow 1.14.0 + Keras 2.2.5 + 'tf.keras' >> optimizers_225tf.py + utils_225t
 TensorFlow 2.0.0  + Keras 2.3.0 + 'keras'    >> optimizers.py       + utils.py
 TensorFlow 2.0.0  + Keras 2.3.0 + 'tf.keras' >> optimizers_v2.py    + utils.py
 ```
+
+[__init__.py](https://github.com/OverLordGoldDragon/keras-adamw/blob/master/keras_adamw/__init__.py) takes care of making the correct selection, but
+still needs `import os; os.environ["TF_KERAS"]='1'` if using `tensorflow.keras` imports, as it cannot determine that automatically.
 
 - `'keras'` --> using `keras` imports. _Ex_: `from keras.layers import Dense`
 - `'tf.keras'` --> using `tensorflow.keras` imports. _Ex_: `from tensorflow.keras.layers import Dense`

--- a/keras_adamw/__init__.py
+++ b/keras_adamw/__init__.py
@@ -1,3 +1,30 @@
-import os
+"""Handles version imports
+   NOTE: if using `tensorflow.keras` imports, use `os.environ["TF_KERAS"] = '1'`,
+         else the default '0' will be assumed for `keras` imports.
+"""
 
-__version__ = '1.13'
+import os
+import tensorflow as tf
+
+TF_KERAS = bool(os.environ.get("TF_KERAS", '0') == '1')
+TF_2 = bool(tf.__version__[0] == '2')
+
+if TF_KERAS:
+    if TF_2:
+        from .optimizers_v2 import AdamW, NadamW, SGDW
+    else:
+        from .optimizers_225tf import AdamW, NadamW, SGDW
+else:
+    if TF_2:
+        from .optimizers import AdamW, NadamW, SGDW
+    else:
+        from .optimizers_225 import AdamW, NadamW, SGDW
+
+if TF_KERAS and not TF_2:
+    from .utils_225tf import get_weight_decays, fill_dict_in_order
+    from .utils_225tf import reset_seeds, K_eval
+else:
+    from .utils import get_weight_decays, fill_dict_in_order
+    from .utils import reset_seeds, K_eval
+
+__version__ = '1.15'

--- a/keras_adamw/optimizers.py
+++ b/keras_adamw/optimizers.py
@@ -171,9 +171,9 @@ class AdamW(Optimizer):
             'lr_multipliers': self.lr_multipliers,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K_eval(self.t_cur)),
-            'eta_t': int(K_eval(self.eta_t)),
-            'eta_min': int(K_eval(self.eta_min)),
-            'eta_max': int(K_eval(self.eta_max)),
+            'eta_t': float(K_eval(self.eta_t)),
+            'eta_min': float(K_eval(self.eta_min)),
+            'eta_max': float(K_eval(self.eta_max)),
             'init_verbose': self.init_verbose,
             'epsilon': self.epsilon,
             'amsgrad': self.amsgrad
@@ -327,9 +327,9 @@ class NadamW(Optimizer):
             'lr_multipliers': self.lr_multipliers,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K_eval(self.t_cur)),
-            'eta_t': int(K_eval(self.eta_t)),
-            'eta_min': int(K_eval(self.eta_min)),
-            'eta_max': int(K_eval(self.eta_max)),
+            'eta_t': float(K_eval(self.eta_t)),
+            'eta_min': float(K_eval(self.eta_min)),
+            'eta_max': float(K_eval(self.eta_max)),
             'init_verbose': self.init_verbose
         }
         base_config = super(NadamW, self).get_config()
@@ -448,9 +448,9 @@ class SGDW(Optimizer):
             'lr_multipliers': self.lr_multipliers,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K_eval(self.t_cur)),
-            'eta_t': int(K_eval(self.eta_t)),
-            'eta_min': int(K_eval(self.eta_min)),
-            'eta_max': int(K_eval(self.eta_max)),
+            'eta_t': float(K_eval(self.eta_t)),
+            'eta_min': float(K_eval(self.eta_min)),
+            'eta_max': float(K_eval(self.eta_max)),
             'init_verbose': self.init_verbose
         }
         base_config = super(SGDW, self).get_config()

--- a/keras_adamw/optimizers_225.py
+++ b/keras_adamw/optimizers_225.py
@@ -160,9 +160,9 @@ class AdamW(Optimizer):
             'lr_multipliers': self.lr_multipliers,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K.get_value(self.t_cur)),
-            'eta_t': int(K.eval(self.eta_t)),
-            'eta_min': int(K.get_value(self.eta_min)),
-            'eta_max': int(K.get_value(self.eta_max)),
+            'eta_t': float(K.eval(self.eta_t)),
+            'eta_min': float(K.get_value(self.eta_min)),
+            'eta_max': float(K.get_value(self.eta_max)),
             'init_verbose': self.init_verbose,
             'epsilon': self.epsilon,
             'amsgrad': self.amsgrad
@@ -304,9 +304,9 @@ class NadamW(Optimizer):
             'lr_multipliers': self.lr_multipliers,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K.get_value(self.t_cur)),
-            'eta_t': int(K.eval(self.eta_t)),
-            'eta_min': int(K.get_value(self.eta_min)),
-            'eta_max': int(K.get_value(self.eta_max)),
+            'eta_t': float(K.eval(self.eta_t)),
+            'eta_min': float(K.get_value(self.eta_min)),
+            'eta_max': float(K.get_value(self.eta_max)),
             'init_verbose': self.init_verbose
         }
         base_config = super(NadamW, self).get_config()
@@ -422,9 +422,9 @@ class SGDW(Optimizer):
             'lr_multipliers': self.lr_multipliers,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K.get_value(self.t_cur)),
-            'eta_t': int(K.eval(self.eta_t)),
-            'eta_min': int(K.get_value(self.eta_min)),
-            'eta_max': int(K.get_value(self.eta_max)),
+            'eta_t': float(K.eval(self.eta_t)),
+            'eta_min': float(K.get_value(self.eta_min)),
+            'eta_max': float(K.get_value(self.eta_max)),
             'init_verbose': self.init_verbose
         }
         base_config = super(SGDW, self).get_config()

--- a/keras_adamw/optimizers_225tf.py
+++ b/keras_adamw/optimizers_225tf.py
@@ -263,9 +263,9 @@ class AdamW(OptimizerV2):
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K.get_value(self.t_cur)),
-            'eta_t': int(K.get_value(self.eta_t)),
-            'eta_min': int(K.get_value(self.eta_min)),
-            'eta_max': int(K.get_value(self.eta_max)),
+            'eta_t': float(K.get_value(self.eta_t)),
+            'eta_min': float(K.get_value(self.eta_min)),
+            'eta_max': float(K.get_value(self.eta_max)),
             'init_verbose': self.init_verbose
         })
         return config
@@ -515,9 +515,9 @@ class NadamW(OptimizerV2):
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K.get_value(self.t_cur)),
-            'eta_t': int(K.get_value(self.eta_t)),
-            'eta_min': int(K.get_value(self.eta_min)),
-            'eta_max': int(K.get_value(self.eta_max)),
+            'eta_t': float(K.get_value(self.eta_t)),
+            'eta_min': float(K.get_value(self.eta_min)),
+            'eta_max': float(K.get_value(self.eta_max)),
             'init_verbose': self.init_verbose
         })
         return config
@@ -683,9 +683,9 @@ class SGDW(OptimizerV2):
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K.get_value(self.t_cur)),
-            'eta_t': int(K.get_value(self.eta_t)),
-            'eta_min': int(K.get_value(self.eta_min)),
-            'eta_max': int(K.get_value(self.eta_max)),
+            'eta_t': float(K.get_value(self.eta_t)),
+            'eta_min': float(K.get_value(self.eta_min)),
+            'eta_max': float(K.get_value(self.eta_max)),
             'init_verbose': self.init_verbose
         })
         return config

--- a/keras_adamw/optimizers_v2.py
+++ b/keras_adamw/optimizers_v2.py
@@ -260,9 +260,9 @@ class AdamW(OptimizerV2):
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K_eval(self.t_cur)),
-            'eta_t': int(K_eval(self.eta_t)),
-            'eta_min': int(K_eval(self.eta_min)),
-            'eta_max': int(K_eval(self.eta_max)),
+            'eta_t': float(K_eval(self.eta_t)),
+            'eta_min': float(K_eval(self.eta_min)),
+            'eta_max': float(K_eval(self.eta_max)),
             'init_verbose': self.init_verbose
         })
         return config
@@ -511,9 +511,9 @@ class NadamW(OptimizerV2):
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K_eval(self.t_cur)),
-            'eta_t': int(K_eval(self.eta_t)),
-            'eta_min': int(K_eval(self.eta_min)),
-            'eta_max': int(K_eval(self.eta_max)),
+            'eta_t': float(K_eval(self.eta_t)),
+            'eta_min': float(K_eval(self.eta_min)),
+            'eta_max': float(K_eval(self.eta_max)),
             'init_verbose': self.init_verbose
         })
         return config
@@ -678,9 +678,9 @@ class SGDW(OptimizerV2):
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
             't_cur': int(K_eval(self.t_cur)),
-            'eta_t': int(K_eval(self.eta_t)),
-            'eta_min': int(K_eval(self.eta_min)),
-            'eta_max': int(K_eval(self.eta_max)),
+            'eta_t': float(K_eval(self.eta_t)),
+            'eta_min': float(K_eval(self.eta_min)),
+            'eta_max': float(K_eval(self.eta_max)),
             'init_verbose': self.init_verbose
         })
         return config

--- a/tests/import_selection.py
+++ b/tests/import_selection.py
@@ -1,39 +1,17 @@
 import os
 
 
-tf_version = float(os.environ["TF_VERSION"][:3])
-tf_keras = bool(os.environ["TF_KERAS"] == "True")
-tf_python = bool(os.environ["TF_PYTHON"] == "True")
+TF_KERAS = bool(os.environ.get("TF_KERAS", '0') == '1')
+TF_2 = bool(os.environ.get("TF_VERSION", '1')[0] == '2')
 
 
-if tf_version >= 2:
-    if tf_keras:
-        from keras_adamw.optimizers_v2 import AdamW, NadamW, SGDW
-    elif tf_python:
-        from keras_adamw.optimizers_tfpy import AdamW, NadamW, SGDW
-    else:
-        from keras_adamw.optimizers import AdamW, NadamW, SGDW
-else:
-    if tf_keras:
-        from keras_adamw.optimizers_225tf import AdamW, NadamW, SGDW
-    else:
-        from keras_adamw.optimizers_225 import AdamW, NadamW, SGDW
-
-if tf_keras:
+if TF_KERAS:
     import tensorflow.keras.backend as K
     from tensorflow.keras.layers import Input, Dense, GRU, Bidirectional, Embedding
     from tensorflow.keras.models import Model, load_model
     from tensorflow.keras.regularizers import l2
     from tensorflow.keras.constraints import MaxNorm as maxnorm
     from tensorflow.keras.optimizers import Adam, Nadam, SGD
-elif tf_python:
-    import tensorflow.keras.backend as K  # tf.python.keras.backend is very buggy
-    from tensorflow.python.keras.layers import Input, Dense, GRU, Bidirectional
-    from tensorflow.python.keras.layers import Embedding
-    from tensorflow.python.keras.models import Model, load_model
-    from tensorflow.python.keras.regularizers import l2
-    from tensorflow.python.keras.constraints import MaxNorm as maxnorm
-    from tensorflow.python.keras.optimizers import Adam, Nadam, SGD
 else:
     import keras.backend as K
     from keras.layers import Input, Dense, GRU, Bidirectional, Embedding
@@ -42,7 +20,7 @@ else:
     from keras.constraints import MaxNorm as maxnorm
     from keras.optimizers import Adam, Nadam, SGD
 
-if tf_version < 2 and tf_keras:
+if (not TF_2) and TF_KERAS:
     from keras_adamw.utils_225tf import get_weight_decays, fill_dict_in_order
     from keras_adamw.utils_225tf import reset_seeds, K_eval
 else:
@@ -50,11 +28,10 @@ else:
     from keras_adamw.utils import reset_seeds, K_eval
 
 
-# ALL TESTS (7 total):
+# ALL TESTS (6 total):
 #  - keras    (TF 1.14.0, Keras 2.2.5) [test_optimizers.py]
 #  - tf.keras (TF 1.14.0, Keras 2.2.5) [test_optimizers_v2.py]
 #  - keras    (TF 2.0.0,  Keras 2.3.0) [test_optimizers.py     --TF_EAGER=True]
 #  - keras    (TF 2.0.0,  Keras 2.3.0) [test_optimizers.py     --TF_EAGER=False]
 #  - tf.keras (TF 2.0.0,  Keras 2.3.0) [test_optimizers_v2.py, --TF_EAGER=True]
 #  - tf.keras (TF 2.0.0,  Keras 2.3.0) [test_optimizers_v2.py, --TF_EAGER=False]
-#  - tf.python.keras (TF 2.0.0,  Keras 2.3.0) [test_optimizers_tfpy.py]

--- a/tests/test_optimizers/test_optimizers.py
+++ b/tests/test_optimizers/test_optimizers.py
@@ -13,13 +13,13 @@ from .. import Model, load_model
 from .. import l2
 from .. import maxnorm
 from .. import Adam, Nadam, SGD
-from .. import AdamW, NadamW, SGDW
-from .. import get_weight_decays, fill_dict_in_order, reset_seeds, K_eval
+from keras_adamw import AdamW, NadamW, SGDW
+from keras_adamw import get_weight_decays, fill_dict_in_order, reset_seeds, K_eval
 
 
 print("TF version: %s" % tf.__version__)
-tf_eager = bool(os.environ["TF_EAGER"] == "True")
-if tf_eager:
+TF_EAGER = bool(os.environ["TF_EAGER"] == "True")
+if TF_EAGER:
     print("TF running eagerly")
 else:
     tf.compat.v1.disable_eager_execution()

--- a/tests/test_optimizers_225/test_optimizers.py
+++ b/tests/test_optimizers_225/test_optimizers.py
@@ -13,13 +13,13 @@ from .. import Model, load_model
 from .. import l2
 from .. import maxnorm
 from .. import Adam, Nadam, SGD
-from .. import AdamW, NadamW, SGDW
-from .. import get_weight_decays, fill_dict_in_order, reset_seeds, K_eval
+from keras_adamw import AdamW, NadamW, SGDW
+from keras_adamw import get_weight_decays, fill_dict_in_order, reset_seeds, K_eval
 
 
 print("TF version: %s" % tf.__version__)
-tf_eager = bool(os.environ["TF_EAGER"] == "True")
-if tf_eager:
+TF_EAGER = bool(os.environ["TF_EAGER"] == "True")
+if TF_EAGER:
     print("TF running eagerly")
 else:
     tf.compat.v1.disable_eager_execution()

--- a/tests/test_optimizers_v2/test_optimizers_v2.py
+++ b/tests/test_optimizers_v2/test_optimizers_v2.py
@@ -13,13 +13,13 @@ from .. import Model, load_model
 from .. import l2
 from .. import maxnorm
 from .. import Adam, Nadam, SGD
-from .. import AdamW, NadamW, SGDW
-from .. import get_weight_decays, fill_dict_in_order, reset_seeds, K_eval
+from keras_adamw import AdamW, NadamW, SGDW
+from keras_adamw import get_weight_decays, fill_dict_in_order, reset_seeds, K_eval
 
 
 print("TF version: %s" % tf.__version__)
-tf_eager = bool(os.environ["TF_EAGER"] == "True")
-if tf_eager:
+TF_EAGER = bool(os.environ["TF_EAGER"] == "True")
+if TF_EAGER:
     print("TF running eagerly")
 else:
     tf.compat.v1.disable_eager_execution()
@@ -55,7 +55,7 @@ class TestOptimizers(TestCase):
                     self.eta_history += [K_eval(self.model.optimizer.eta_t, K)]
                     self.model.train_on_batch(X[batch_num], Y[batch_num])
                     self.eta_history += [K_eval(self.model.optimizer.eta_t, K)]
-                    self.eta_history.pop(-(1 + int(tf_eager)))
+                    self.eta_history.pop(-(1 + int(TF_EAGER)))
                 K.set_value(self.model.optimizer.t_cur, 0)
 
             self.assertTrue(self._valid_cosine_annealing(self.eta_history,


### PR DESCRIPTION
**New features**:

 - Simplified imports; just use `from keras_adamw import` for both the optimizers and utils, only requiring `import os; os.environ["TF_KERAS"]='1'` if using `tensorflow.keras` imports.

**Breaking changes**:

 - Environment flags are now set via `'1'` and `'0'`, instead of `'True'` and `'False'`

**Bug fixes**:
 
 - `get_configs()` incorrectly cast `eta_min`, `eta_max`, and `eta_t` via `int` - changed to `float`