### PR TITLE
Improve optimizer selection, change input signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Keras implementation of **AdamW**, **SGDW**, **NadamW**, and **Warm Restarts**, 
 If using tensorflow.keras imports, set `import os; os.environ["TF_KERAS"]='1'`.
 
 ### Weight decay
-`AdamW(model)`<br>
+`AdamW(model=model)`<br>
 Three methods to set `weight_decays = {<weight matrix name>:<weight decay value>,}`:
 
 ```python
 # 1. Automatically
-Just pass in `model` (`AdamW(model)`), and decays will be automatically extracted.
+Just pass in `model` (`AdamW(model=model)`), and decays will be automatically extracted.
 Loss-based penalties (l1, l2, l1_l2) will be zeroed by default, but can be kept via
 `zero_penalties=False` (NOT recommended, see Use guidelines).
 ```
@@ -84,7 +84,7 @@ model = Model(ipt,out)
 ```python
 lr_multipliers = {'lstm_1':0.5}
 
-optimizer = AdamW(model, lr=1e-4, lr_multipliers=lr_multipliers,
+optimizer = AdamW(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                   use_cosine_annealing=True, total_iterations=24)
 model.compile(optimizer, loss='binary_crossentropy')
 ```

--- a/example.py
+++ b/example.py
@@ -13,11 +13,11 @@ ipt   = Input(shape=(120,4))
 x     = LSTM(60, activation='relu', name='lstm_1',
              kernel_regularizer=l1(1e-4), recurrent_regularizer=l2(2e-4))(ipt)
 out   = Dense(1, activation='sigmoid', kernel_regularizer=l1_l2(1e-4))(x)
-model = Model(ipt,out)
+model = Model(ipt, out)
 
 lr_multipliers = {'lstm_1': 0.5}
 
-optimizer = AdamW(model, lr=1e-4, lr_multipliers=lr_multipliers,
+optimizer = AdamW(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                   use_cosine_annealing=True, total_iterations=24)
 model.compile(optimizer, loss='binary_crossentropy')
 

--- a/keras_adamw/__init__.py
+++ b/keras_adamw/__init__.py
@@ -29,4 +29,4 @@ from .utils_common import get_weight_decays, fill_dict_in_order
 from .utils_common import reset_seeds, K_eval
 
 
-__version__ = '1.2'
+__version__ = '1.21'

--- a/keras_adamw/__init__.py
+++ b/keras_adamw/__init__.py
@@ -5,6 +5,12 @@
 import os
 import tensorflow as tf
 
+try:
+    import keras
+    KERAS_23 = bool(keras.__version__[:3] == '2.3')
+except:
+    KERAS_23 = None
+
 TF_KERAS = bool(os.environ.get("TF_KERAS", '0') == '1')
 TF_2 = bool(tf.__version__[0] == '2')
 
@@ -14,7 +20,7 @@ if TF_KERAS:
     else:
         from .optimizers_225tf import AdamW, NadamW, SGDW
 else:
-    if TF_2:
+    if TF_2 or KERAS_23:
         from .optimizers import AdamW, NadamW, SGDW
     else:
         from .optimizers_225 import AdamW, NadamW, SGDW

--- a/keras_adamw/optimizers.py
+++ b/keras_adamw/optimizers.py
@@ -27,13 +27,17 @@ class AdamW(Optimizer):
         amsgrad: boolean. Whether to apply the AMSGrad variant of this
             algorithm from the paper "On the Convergence of Adam and Beyond".
 
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
         batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
-        weight_decays:    dict / None. Name-value pairs specifying weight decays,
-                          as {<weight matrix name>:<weight decay value>}; <2>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
                           multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
 
         use_cosine_annealing: bool. If True, multiplies lr each train iteration
                               as a function of eta_min, eta_max, total_iterations,
@@ -64,9 +68,10 @@ class AdamW(Optimizer):
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
-                 amsgrad=False, batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 amsgrad=False, model=None, zero_penalties=True,
+                 batch_size=32, total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
         self.initial_decay = kwargs.pop('decay', 0.0)
         self.epsilon = kwargs.pop('epsilon', K.epsilon())
@@ -208,18 +213,53 @@ class NadamW(Optimizer):
         beta_1/beta_2: floats, 0 < beta < 1. Generally close to 1.
         epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [3]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [3]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [3]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+            (https://github.com/OverLordGoldDragon/keras_adamw)
 
     # References
-        - [Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
-        - [On the importance of initialization and momentum in deep learning]
-          (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+        - [1][Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
+        - [2][On the importance of initialization and momentum in deep learning]
+             (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+        - [3][Fixing Weight Decay Regularization in Adam]
+             (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.002, beta_1=0.9, beta_2=0.999,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
         self.schedule_decay = kwargs.pop('schedule_decay', 0.004)
         self.epsilon = kwargs.pop('epsilon', K.epsilon())
@@ -360,13 +400,52 @@ class SGDW(Optimizer):
         decay: float >= 0. Learning rate decay over each update.
         nesterov: boolean. Whether to apply Nesterov momentum.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [2]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [2]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [2]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+        (https://github.com/OverLordGoldDragon/keras_adamw)
+
+    # References
+    - [1][Adam - A Method for Stochastic Optimization]
+         (http://arxiv.org/abs/1412.6980v8)
+    - [2][Fixing Weight Decay Regularization in Adam]
+         (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.01, momentum=0., nesterov=False,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
         self.initial_decay = kwargs.pop('decay', 0.0)
         learning_rate = kwargs.pop('lr', learning_rate)

--- a/keras_adamw/optimizers.py
+++ b/keras_adamw/optimizers.py
@@ -66,13 +66,14 @@ class AdamW(Optimizer):
         - [2][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  amsgrad=False, model=None, zero_penalties=True,
                  batch_size=32, total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
+
         self.initial_decay = kwargs.pop('decay', 0.0)
         self.epsilon = kwargs.pop('epsilon', K.epsilon())
         learning_rate = kwargs.pop('lr', learning_rate)
@@ -254,13 +255,14 @@ class NadamW(Optimizer):
         - [3][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.002, beta_1=0.9, beta_2=0.999,
                  model=None, zero_penalties=True, batch_size=32,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
+
         self.schedule_decay = kwargs.pop('schedule_decay', 0.004)
         self.epsilon = kwargs.pop('epsilon', K.epsilon())
         learning_rate = kwargs.pop('lr', learning_rate)
@@ -440,13 +442,14 @@ class SGDW(Optimizer):
     - [2][Fixing Weight Decay Regularization in Adam]
          (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.01, momentum=0., nesterov=False,
                  model=None, zero_penalties=True, batch_size=32,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
+
         self.initial_decay = kwargs.pop('decay', 0.0)
         learning_rate = kwargs.pop('lr', learning_rate)
         eta_t = kwargs.pop('eta_t', 1.)

--- a/keras_adamw/optimizers_225.py
+++ b/keras_adamw/optimizers_225.py
@@ -10,24 +10,23 @@ class AdamW(Optimizer):
     """AdamW optimizer.
     Default parameters follow those provided in the original paper.
     # Arguments
-        model: keras.Model/tf.keras.Model. Pass as first positional argument
-            to constructor (AdamW(model, ...)). If passed, automatically extracts
-            weight penalties from layers and overrides `weight_decays`.
-        zero_penalties: bool. If True and `model` is passed, will zero weight
-            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
         lr: float >= 0. Learning rate.
         beta_1: float, 0 < beta < 1. Generally close to 1.
         beta_2: float, 0 < beta < 1. Generally close to 1.
         amsgrad: boolean. Whether to apply the AMSGrad variant of this
             algorithm from the paper "On the Convergence of Adam and Beyond".
 
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
         batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
-        weight_decays:    dict / None. Name-value pairs specifying weight decays,
-                          as {<weight matrix name>:<weight decay value>}; <2>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
                           multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
 
         use_cosine_annealing: bool. If True, multiplies lr each train iteration
                               as a function of eta_min, eta_max, total_iterations,
@@ -58,9 +57,10 @@ class AdamW(Optimizer):
     """
     @_init_weight_decays
     def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999, amsgrad=False,
-                 epsilon=None, decay=0.0, batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 epsilon=None, decay=0.0, model=None, zero_penalties=True,
+                 batch_size=32, total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
         eta_t = kwargs.pop('eta_t', 1.)
         super(AdamW, self).__init__(**kwargs)
@@ -191,19 +191,54 @@ class NadamW(Optimizer):
         beta_1/beta_2: floats, 0 < beta < 1. Generally close to 1.
         epsilon: float >= 0. Fuzz factor. If `None`, defaults to `K.epsilon()`.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [3]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [3]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [3]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+            (https://github.com/OverLordGoldDragon/keras_adamw)
 
     # References
-        - [Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
-        - [On the importance of initialization and momentum in deep learning]
-          (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+        - [1][Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
+        - [2][On the importance of initialization and momentum in deep learning]
+             (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+        - [3][Fixing Weight Decay Regularization in Adam]
+             (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
                  schedule_decay=0.004, epsilon=None,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
         eta_t = kwargs.pop('eta_t', 1.)
         super(NadamW, self).__init__(**kwargs)
@@ -331,13 +366,52 @@ class SGDW(Optimizer):
         decay: float >= 0. Learning rate decay over each update.
         nesterov: boolean. Whether to apply Nesterov momentum.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [2]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [2]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [2]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+        (https://github.com/OverLordGoldDragon/keras_adamw)
+
+    # References
+    - [1][Adam - A Method for Stochastic Optimization]
+         (http://arxiv.org/abs/1412.6980v8)
+    - [2][Fixing Weight Decay Regularization in Adam]
+         (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, lr=0.01, momentum=0., nesterov=False, decay=0.0,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
         eta_t = kwargs.pop('eta_t', 1.)
         super(SGDW, self).__init__(**kwargs)

--- a/keras_adamw/optimizers_225.py
+++ b/keras_adamw/optimizers_225.py
@@ -55,13 +55,13 @@ class AdamW(Optimizer):
         - [2][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999, amsgrad=False,
                  epsilon=None, decay=0.0, model=None, zero_penalties=True,
                  batch_size=32, total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
         eta_t = kwargs.pop('eta_t', 1.)
         super(AdamW, self).__init__(**kwargs)
 
@@ -232,7 +232,6 @@ class NadamW(Optimizer):
         - [3][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
                  schedule_decay=0.004, epsilon=None,
                  model=None, zero_penalties=True, batch_size=32,
@@ -240,6 +239,7 @@ class NadamW(Optimizer):
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
         eta_t = kwargs.pop('eta_t', 1.)
         super(NadamW, self).__init__(**kwargs)
 
@@ -406,13 +406,13 @@ class SGDW(Optimizer):
     - [2][Fixing Weight Decay Regularization in Adam]
          (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, lr=0.01, momentum=0., nesterov=False, decay=0.0,
                  model=None, zero_penalties=True, batch_size=32,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
         eta_t = kwargs.pop('eta_t', 1.)
         super(SGDW, self).__init__(**kwargs)
 

--- a/keras_adamw/optimizers_225tf.py
+++ b/keras_adamw/optimizers_225tf.py
@@ -43,13 +43,17 @@ class AdamW(OptimizerV2):
             allow time inverse decay of learning rate. `lr` is included for
             backward compatibility, recommended to use `learning_rate` instead.
 
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
         batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
-        weight_decays:    dict / None. Name-value pairs specifying weight decays,
-                          as {<weight matrix name>:<weight decay value>}; <2>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
                           multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
 
         use_cosine_annealing: bool. If True, multiplies lr each train iteration
                               as a function of eta_min, eta_max, total_iterations,
@@ -81,9 +85,10 @@ class AdamW(OptimizerV2):
     @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=None, decay=0., amsgrad=False,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
         eta_t = kwargs.pop('eta_t', 1.)
 
@@ -303,21 +308,54 @@ class NadamW(OptimizerV2):
         allow time inverse decay of learning rate. `lr` is included for backward
         compatibility, recommended to use `learning_rate` instead.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [3]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [3]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [3]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+            (https://github.com/OverLordGoldDragon/keras_adamw)
 
     # References
-        - [Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
-        - [On the importance of initialization and momentum in deep learning]
-          (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
-        - [Fixing Weight Decay Regularization in Adam]
-          (https://arxiv.org/abs/1711.05101)
+        - [1][Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
+        - [2][On the importance of initialization and momentum in deep learning]
+             (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+        - [3][Fixing Weight Decay Regularization in Adam]
+             (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-7, batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
-                 eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
+                 epsilon=1e-7, model=None, zero_penalties=True,
+                 batch_size=32, total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
+                 eta_min=0, eta_max=1, t_cur=0, name="NadamW", **kwargs):
 
         # Backwards compatibility with keras NAdam optimizer.
         kwargs['decay'] = kwargs.pop('schedule_decay', 0.004)
@@ -549,14 +587,53 @@ class SGDW(OptimizerV2):
             allow time inverse decay of learning rate. `lr` is included for
             backward compatibility, recommended to use `learning_rate` instead.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [2]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [2]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [2]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+        (https://github.com/OverLordGoldDragon/keras_adamw)
+
+    # References
+    - [1][Adam - A Method for Stochastic Optimization]
+         (http://arxiv.org/abs/1412.6980v8)
+    - [2][Fixing Weight Decay Regularization in Adam]
+         (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.01, momentum=0.0, nesterov=False,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
-                 eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
+                 eta_min=0, eta_max=1, t_cur=0, name="SGDW", **kwargs):
 
         eta_t = kwargs.pop('eta_t', 1.)
         super(SGDW, self).__init__(name, **kwargs)

--- a/keras_adamw/optimizers_225tf.py
+++ b/keras_adamw/optimizers_225tf.py
@@ -82,7 +82,6 @@ class AdamW(OptimizerV2):
         - [2][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=None, decay=0., amsgrad=False,
                  model=None, zero_penalties=True, batch_size=32,
@@ -90,6 +89,7 @@ class AdamW(OptimizerV2):
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
         eta_t = kwargs.pop('eta_t', 1.)
 
         super(AdamW, self).__init__(name, **kwargs)
@@ -349,13 +349,13 @@ class NadamW(OptimizerV2):
         - [3][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=1e-7, model=None, zero_penalties=True,
                  batch_size=32, total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="NadamW", **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
 
         # Backwards compatibility with keras NAdam optimizer.
         kwargs['decay'] = kwargs.pop('schedule_decay', 0.004)
@@ -627,13 +627,13 @@ class SGDW(OptimizerV2):
     - [2][Fixing Weight Decay Regularization in Adam]
          (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.01, momentum=0.0, nesterov=False,
                  model=None, zero_penalties=True, batch_size=32,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="SGDW", **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
 
         eta_t = kwargs.pop('eta_t', 1.)
         super(SGDW, self).__init__(name, **kwargs)

--- a/keras_adamw/optimizers_v2.py
+++ b/keras_adamw/optimizers_v2.py
@@ -48,13 +48,17 @@ class AdamW(OptimizerV2):
             allow time inverse decay of learning rate. `lr` is included for
             backward compatibility, recommended to use `learning_rate` instead.
 
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
         batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
-        weight_decays:    dict / None. Name-value pairs specifying weight decays,
-                          as {<weight matrix name>:<weight decay value>}; <2>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
                           multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
 
         use_cosine_annealing: bool. If True, multiplies lr each train iteration
                               as a function of eta_min, eta_max, total_iterations,
@@ -86,9 +90,10 @@ class AdamW(OptimizerV2):
     @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=None, decay=0., amsgrad=False,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
         eta_t = kwargs.pop('eta_t', 1.)
 
@@ -305,21 +310,54 @@ class NadamW(OptimizerV2):
         allow time inverse decay of learning rate. `lr` is included for backward
         compatibility, recommended to use `learning_rate` instead.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [3]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [3]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [3]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+            (https://github.com/OverLordGoldDragon/keras_adamw)
 
     # References
-        - [Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
-        - [On the importance of initialization and momentum in deep learning]
-          (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
-        - [Fixing Weight Decay Regularization in Adam]
-          (https://arxiv.org/abs/1711.05101)
+        - [1][Nadam report](http://cs229.stanford.edu/proj2015/054_report.pdf)
+        - [2][On the importance of initialization and momentum in deep learning]
+             (http://www.cs.toronto.edu/~fritz/absps/momentum.pdf)
+        - [3][Fixing Weight Decay Regularization in Adam]
+             (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-7, batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
-                 eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
+                 epsilon=1e-7, model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
+                 eta_min=0, eta_max=1, t_cur=0, name="NadamW", **kwargs):
 
         # Backwards compatibility with keras NAdam optimizer.
         kwargs['decay'] = kwargs.pop('schedule_decay', 0.004)
@@ -550,14 +588,53 @@ class SGDW(OptimizerV2):
             allow time inverse decay of learning rate. `lr` is included for
             backward compatibility, recommended to use `learning_rate` instead.
 
-    # Arguments (other): see help(AdamW)
+        model: keras.Model/tf.keras.Model/None. If not None, automatically
+            extracts weight penalties from layers, and overrides `weight_decays`.
+        zero_penalties: bool. If True and `model` is passed, will zero weight
+            penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
+        batch_size:       int >= 1. Train input batch size; used for normalization
+        total_iterations: int >= 0. Total expected iterations / weight updates
+                          throughout training, used for normalization; <1>
+        lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
+                          multipliers, as {<layer name>:<multiplier value>}; <2>
+        weight_decays:    dict / None. Name-value pairs specifying weight decays,
+                          as {<weight matrix name>:<weight decay value>}; <2>
+
+        use_cosine_annealing: bool. If True, multiplies lr each train iteration
+                              as a function of eta_min, eta_max, total_iterations,
+                              and t_cur (current); [2]-Appendix, 2
+        eta_min, eta_max: int, int. Min & max values of cosine annealing
+                          lr multiplier; [2]-Appendix, 2
+        t_cur: int. Value to initialize t_cur to - used for 'warm restarts'.
+               To be used together with use_cosine_annealing==True
+        total_iterations_wd: int / None. If not None, weight_decays will be
+                     applied according to total_iterations_wd instead of
+                     total_iterations, contrary to authors' scheme. Set to
+                     sum(total_iterations) over all restarts to normalize over
+                     all epochs. May yield improvement over `None`.
+        init_verbose: bool. If True, print weight-name--weight-decay, and
+                      lr-multiplier--layer-name value pairs set during
+                      optimizer initialization (recommended)
+
+    # <1> - if using 'warm restarts', then refers to total expected iterations
+        for a given restart; can be an estimate, and training won't stop
+        at iterations == total_iterations. [2]-Appendix, pg 1
+    # <2> - [AdamW Keras Implementation - Github repository]
+        (https://github.com/OverLordGoldDragon/keras_adamw)
+
+    # References
+    - [1][Adam - A Method for Stochastic Optimization]
+         (http://arxiv.org/abs/1412.6980v8)
+    - [2][Fixing Weight Decay Regularization in Adam]
+         (https://arxiv.org/abs/1711.05101)
     """
     @_init_weight_decays
     def __init__(self, learning_rate=0.01, momentum=0.0, nesterov=False,
-                 batch_size=32, total_iterations=0,
-                 total_iterations_wd=None, use_cosine_annealing=False,
-                 weight_decays=None, lr_multipliers=None, init_verbose=True,
-                 eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
+                 model=None, zero_penalties=True, batch_size=32,
+                 total_iterations=0, total_iterations_wd=None,
+                 use_cosine_annealing=False, lr_multipliers=None,
+                 weight_decays=None, init_verbose=True,
+                 eta_min=0, eta_max=1, t_cur=0, name="SGDW", **kwargs):
 
         eta_t = kwargs.pop('eta_t', 1.)
         super(SGDW, self).__init__(name, **kwargs)

--- a/keras_adamw/optimizers_v2.py
+++ b/keras_adamw/optimizers_v2.py
@@ -87,7 +87,6 @@ class AdamW(OptimizerV2):
         - [2][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=None, decay=0., amsgrad=False,
                  model=None, zero_penalties=True, batch_size=32,
@@ -95,6 +94,7 @@ class AdamW(OptimizerV2):
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="AdamW", **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
         eta_t = kwargs.pop('eta_t', 1.)
 
         super(AdamW, self).__init__(name, **kwargs)
@@ -351,13 +351,13 @@ class NadamW(OptimizerV2):
         - [3][Fixing Weight Decay Regularization in Adam]
              (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=1e-7, model=None, zero_penalties=True, batch_size=32,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="NadamW", **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
 
         # Backwards compatibility with keras NAdam optimizer.
         kwargs['decay'] = kwargs.pop('schedule_decay', 0.004)
@@ -628,13 +628,13 @@ class SGDW(OptimizerV2):
     - [2][Fixing Weight Decay Regularization in Adam]
          (https://arxiv.org/abs/1711.05101)
     """
-    @_init_weight_decays
     def __init__(self, learning_rate=0.01, momentum=0.0, nesterov=False,
                  model=None, zero_penalties=True, batch_size=32,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="SGDW", **kwargs):
+        weight_decays = _init_weight_decays(model, zero_penalties, weight_decays)
 
         eta_t = kwargs.pop('eta_t', 1.)
         super(SGDW, self).__init__(name, **kwargs)

--- a/keras_adamw/utils_common.py
+++ b/keras_adamw/utils_common.py
@@ -8,24 +8,16 @@ from termcolor import colored
 WARN = colored('WARNING:', 'red')
 
 
-def _init_weight_decays(init_fn):
-    def get_and_zero_decays(cls, *args, **kwargs):
-        model          = kwargs.pop('model', None)
-        zero_penalties = kwargs.pop('zero_penalties', True)
-        weight_decays  = kwargs.pop('weight_decays', None)
-
-        if not zero_penalties:
-            print(WARN, "loss-based weight penalties should be set to zero. "
-                  "(set `zero_penalties=True`)")
-        if weight_decays is not None and model is not None:
-            print(WARN, "`weight_decays` is set automatically when "
-                  "passing in `model`; will override supplied")
-        if model is not None:
-            weight_decays = get_weight_decays(model, zero_penalties)
-        kwargs['weight_decays'] = weight_decays
-
-        init_fn(cls, *args, **kwargs)
-    return get_and_zero_decays
+def _init_weight_decays(model, zero_penalties, weight_decays):
+    if not zero_penalties:
+        print(WARN, "loss-based weight penalties should be set to zero. "
+              "(set `zero_penalties=True`)")
+    if weight_decays is not None and model is not None:
+        print(WARN, "`weight_decays` is set automatically when "
+              "passing in `model`; will override supplied")
+    if model is not None:
+        weight_decays = get_weight_decays(model, zero_penalties)
+    return weight_decays
 
 
 def get_weight_decays(model, zero_penalties=False, verbose=1):

--- a/keras_adamw/utils_common.py
+++ b/keras_adamw/utils_common.py
@@ -9,20 +9,22 @@ WARN = colored('WARNING:', 'red')
 
 
 def _init_weight_decays(init_fn):
-    def get_and_zero_decays(cls, model=None, **kwargs):
+    def get_and_zero_decays(cls, *args, **kwargs):
+        model          = kwargs.pop('model', None)
         zero_penalties = kwargs.pop('zero_penalties', True)
-        weight_decays = kwargs.pop('weight_decays', None)
+        weight_decays  = kwargs.pop('weight_decays', None)
+
         if not zero_penalties:
             print(WARN, "loss-based weight penalties should be set to zero. "
                   "(set `zero_penalties=True`)")
-
         if weight_decays is not None and model is not None:
             print(WARN, "`weight_decays` is set automatically when "
                   "passing in `model`; will override supplied")
         if model is not None:
             weight_decays = get_weight_decays(model, zero_penalties)
+        kwargs['weight_decays'] = weight_decays
 
-        init_fn(cls, weight_decays=weight_decays, **kwargs)
+        init_fn(cls, *args, **kwargs)
     return get_and_zero_decays
 
 

--- a/tests/test_optimizers/test_optimizers.py
+++ b/tests/test_optimizers/test_optimizers.py
@@ -103,8 +103,8 @@ class TestOptimizers(TestCase):
             # util test
             dc = {'lstm': 0, 'dense': 0}
             fill_dict_in_order(dc, [1e-4, 2e-4])
-            AdamW(self.model, zero_penalties=True)
-            AdamW(self.model, weight_decays={'a': 0})
+            AdamW(model=self.model, zero_penalties=True)
+            AdamW(model=self.model, weight_decays={'a': 0})
 
             # cleanup
             del self.model, optimizer
@@ -289,7 +289,7 @@ class TestOptimizers(TestCase):
             use_cosine_annealing = False
 
         if not any([optimizer_name == name for name in ('Adam', 'Nadam', 'SGD')]):
-            return optimizer(model, lr=1e-4, lr_multipliers=lr_multipliers,
+            return optimizer(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                              use_cosine_annealing=use_cosine_annealing, t_cur=0,
                              total_iterations=total_iterations, **optimizer_kw)
         else:

--- a/tests/test_optimizers_225/test_optimizers.py
+++ b/tests/test_optimizers_225/test_optimizers.py
@@ -103,8 +103,8 @@ class TestOptimizers(TestCase):
             # util test
             dc = {'lstm': 0, 'dense': 0}
             fill_dict_in_order(dc, [1e-4, 2e-4])
-            AdamW(self.model, zero_penalties=True)
-            AdamW(self.model, weight_decays={'a': 0})
+            AdamW(model=self.model, zero_penalties=True)
+            AdamW(model=self.model, weight_decays={'a': 0})
 
             # cleanup
             del self.model, optimizer
@@ -289,7 +289,7 @@ class TestOptimizers(TestCase):
             use_cosine_annealing = False
 
         if not any([optimizer_name == name for name in ('Adam', 'Nadam', 'SGD')]):
-            return optimizer(model, lr=1e-4, lr_multipliers=lr_multipliers,
+            return optimizer(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                              use_cosine_annealing=use_cosine_annealing, t_cur=0,
                              total_iterations=total_iterations, **optimizer_kw)
         else:

--- a/tests/test_optimizers_225tf/test_optimizers_v2.py
+++ b/tests/test_optimizers_225tf/test_optimizers_v2.py
@@ -103,8 +103,8 @@ class TestOptimizers(TestCase):
             # util test
             dc = {'lstm': 0, 'dense': 0}
             fill_dict_in_order(dc, [1e-4, 2e-4])
-            AdamW(self.model, zero_penalties=True)
-            AdamW(self.model, weight_decays={'a': 0})
+            AdamW(model=self.model, zero_penalties=True)
+            AdamW(model=self.model, weight_decays={'a': 0})
 
             # cleanup
             del self.model, optimizer
@@ -287,7 +287,7 @@ class TestOptimizers(TestCase):
             use_cosine_annealing = False
 
         if not any([optimizer_name == name for name in ('Adam', 'Nadam', 'SGD')]):
-            return optimizer(model, lr=1e-4, lr_multipliers=lr_multipliers,
+            return optimizer(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                              use_cosine_annealing=use_cosine_annealing, t_cur=0,
                              total_iterations=total_iterations, **optimizer_kw)
         else:

--- a/tests/test_optimizers_v2/test_optimizers_v2.py
+++ b/tests/test_optimizers_v2/test_optimizers_v2.py
@@ -103,8 +103,8 @@ class TestOptimizers(TestCase):
             # util test
             dc = {'lstm': 0, 'dense': 0}
             fill_dict_in_order(dc, [1e-4, 2e-4])
-            AdamW(self.model, zero_penalties=True)
-            AdamW(self.model, weight_decays={'a': 0})
+            AdamW(model=self.model, zero_penalties=True)
+            AdamW(model=self.model, weight_decays={'a': 0})
 
             # cleanup
             del self.model, optimizer
@@ -287,7 +287,7 @@ class TestOptimizers(TestCase):
             use_cosine_annealing = False
 
         if not any([optimizer_name == name for name in ('Adam', 'Nadam', 'SGD')]):
-            return optimizer(model, lr=1e-4, lr_multipliers=lr_multipliers,
+            return optimizer(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                              use_cosine_annealing=use_cosine_annealing, t_cur=0,
                              total_iterations=total_iterations, **optimizer_kw)
         else:


### PR DESCRIPTION
**FEATURES**:

 - `from keras_adamw import` now accounts for TF 1.x + Keras 2.3.x case
 - `model` and `zero_penalties` now show up in optimizer constructor input signatures, making them cleared and more Pythonic
 - Each optimizer now has its own full docstring, instead of deferring to `help(AdamW)`

**BREAKING**:

 - `model` is no longer to be passed as first positional argument, but as a later one, or a keyword argument

**BUGFIXES**:

 - `name` defaults corrected, many were `"AdamW"` even if not AdamW - though no bugs were encountered as a result

**MISC**:

 - `__init__` wrapper moved inside of `__init__` to avoid overriding input signature