### PR TITLE
Synchronize updates; fix AdamW lr_t (keras)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ for epoch in range(3):
 	    K.set_value(model.optimizer.t_cur, -1) # WARM RESTART: reset cosine annealing argument
     print("EPOCH {} COMPLETED\n".format(epoch + 1))
 ```
-<img src="https://user-images.githubusercontent.com/16495490/83707138-51d56c00-a62a-11ea-9eba-60284490992b.png" width="480">
+<img src="https://user-images.githubusercontent.com/16495490/83707138-51d56c00-a62a-11ea-9eba-60284490992b.png" width="470">
 
 (Full example + plot code, and explanation of `lr_t` vs. `lr`: [example.py](https://github.com/OverLordGoldDragon/keras-adamw/blob/master/example.py))
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ for epoch in range(3):
 ```
 <img src="https://user-images.githubusercontent.com/16495490/65729113-2063d400-e08b-11e9-8b6a-3a2ea1c62fdd.png" width="450">
 
-(Full example + plot code: [example.py](https://github.com/OverLordGoldDragon/keras-adamw/blob/master/example.py))
+(Full example + plot code, and explanation of `lr_t` vs. `lr`: [example.py](https://github.com/OverLordGoldDragon/keras-adamw/blob/master/example.py))
 
 ## Use guidelines
 ### Weight decay

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ for epoch in range(3):
 	    K.set_value(model.optimizer.t_cur, -1) # WARM RESTART: reset cosine annealing argument
     print("EPOCH {} COMPLETED\n".format(epoch + 1))
 ```
-<img src="https://user-images.githubusercontent.com/16495490/65729113-2063d400-e08b-11e9-8b6a-3a2ea1c62fdd.png" width="450">
+<img src="https://user-images.githubusercontent.com/16495490/83707138-51d56c00-a62a-11ea-9eba-60284490992b.png" width="480">
 
 (Full example + plot code, and explanation of `lr_t` vs. `lr`: [example.py](https://github.com/OverLordGoldDragon/keras-adamw/blob/master/example.py))
 

--- a/example.py
+++ b/example.py
@@ -4,11 +4,12 @@ from keras.regularizers import l1, l2, l1_l2
 from keras import backend as K
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 
 from keras_adamw import AdamW
 from keras_adamw.utils import K_eval
 
-
+#%%############################################################################
 ipt   = Input(shape=(120,4))
 x     = LSTM(60, activation='relu', name='lstm_1',
              kernel_regularizer=l1(1e-4), recurrent_regularizer=l2(2e-4))(ipt)
@@ -21,22 +22,40 @@ optimizer = AdamW(lr=1e-4, model=model, lr_multipliers=lr_multipliers,
                   use_cosine_annealing=True, total_iterations=24)
 model.compile(optimizer, loss='binary_crossentropy')
 
+#%%############################################################################
 eta_history = []
+lr_history = []
 for epoch in range(3):
     for iteration in range(24):
         x = np.random.rand(10, 120, 4)  # dummy data
         y = np.random.randint(0, 2, (10, 1))  # dummy labels
         loss = model.train_on_batch(x, y)
         eta_history.append(K_eval(model.optimizer.eta_t, K))
+        lr_history.append(K_eval(model.optimizer.lr_t, K))
         print("Iter {} loss: {}".format(iteration + 1, "%.3f" % loss))
         if iteration == (24 - 2):
             K.set_value(model.optimizer.t_cur, -1)  # WARM RESTART
     print("EPOCH {} COMPLETED\n".format(epoch + 1))
 
-plt.plot(eta_history, linewidth=2)
-plt.xlim(0, len(eta_history))
-plt.ylim(0, 1.05)
-plt.ylabel('eta_t', weight='bold', fontsize=15)
-plt.xlabel('Train iterations', weight='bold', fontsize=15)
-plt.gcf().set_size_inches(10, 5)
+# learning rate at iteration `t` (lr_t) is subject to scaling depending on
+# optimizer; Adam and Nadam use betas (1 & 2), SGD w/ momentum uses beta.
+# -W optimizers additionally scale by eta_t. The lr_t plots reflect the
+# ultimate learning rate as a result of all the scalings.
+
+#%%############################################################################
+_, ax = plt.subplots(figsize=(10, 5))
+ax.plot(eta_history, linewidth=2)
+ax.set_xlim(0, len(eta_history))
+ax.set_ylim(0, 1.05)
+ax.set_ylabel('eta_t', weight='bold', fontsize=15)
+ax.set_xlabel('Train iterations', weight='bold', fontsize=15)
+ax.yaxis.set_major_formatter(ticker.FormatStrFormatter('%0.0e'))
+
+_, ax = plt.subplots(figsize=(10, 5))
+ax.plot(lr_history, linewidth=2)
+ax.set_xlim(0, len(lr_history))
+ax.set_ylim(0, 1.05 * np.max(lr_history))
+ax.set_ylabel('lr_t', weight='bold', fontsize=15)
+ax.set_xlabel('Train iterations', weight='bold', fontsize=15)
+ax.yaxis.set_major_formatter(ticker.FormatStrFormatter('%0.0e'))
 plt.show()

--- a/keras_adamw/optimizers.py
+++ b/keras_adamw/optimizers.py
@@ -148,10 +148,11 @@ class AdamW(Optimizer):
             v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
             if self.amsgrad:
                 vhat_t = K.maximum(vhat, v_t)
-                p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
+                p_t = p - self.eta_t * lr_t * m_t / (
+                    K.sqrt(vhat_t) + self.epsilon)
                 self.updates.append(K.update(vhat, vhat_t))
             else:
-                p_t = p - lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
+                p_t = p - self.eta_t * lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
 
             self.updates.append(K.update(m, m_t))
             self.updates.append(K.update(v, v_t))

--- a/keras_adamw/optimizers_225.py
+++ b/keras_adamw/optimizers_225.py
@@ -123,15 +123,16 @@ class AdamW(Optimizer):
 
             m_t = (self.beta_1 * m) + (1. - self.beta_1) * g
             v_t = (self.beta_2 * v) + (1. - self.beta_2) * K.square(g)
-            if self.amsgrad:
-                vhat_t = K.maximum(vhat, v_t)
-                p_t = p - lr_t * m_t / (K.sqrt(vhat_t) + self.epsilon)
-                self.updates.append(K.update(vhat, vhat_t))
-            else:
-                p_t = p - lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
-
             self.updates.append(K.update(m, m_t))
             self.updates.append(K.update(v, v_t))
+
+            if self.amsgrad:
+                vhat_t = K.maximum(vhat, v_t)
+                p_t = p - self.eta_t * lr_t * m_t / (
+                    K.sqrt(vhat_t) + self.epsilon)
+                self.updates.append(K.update(vhat, vhat_t))
+            else:
+                p_t = p - self.eta_t * lr_t * m_t / (K.sqrt(v_t) + self.epsilon)
 
             # Weight decays
             if p.name in self.weight_decays.keys():
@@ -306,8 +307,9 @@ class NadamW(Optimizer):
 
             self.updates.append(K.update(m, m_t))
             self.updates.append(K.update(v, v_t))
+
             p_t = p - self.eta_t * lr_t * m_t_bar / (
-                    K.sqrt(v_t_prime) + self.epsilon)
+                K.sqrt(v_t_prime) + self.epsilon)
 
             # Weight decays
             if p.name in self.weight_decays.keys():

--- a/keras_adamw/optimizers_225tf.py
+++ b/keras_adamw/optimizers_225tf.py
@@ -6,7 +6,7 @@ from tensorflow.python.ops import array_ops, control_flow_ops, math_ops, state_o
 from tensorflow.python.util.tf_export import keras_export
 from tensorflow.keras import backend as K
 from .utils import _init_weight_decays, _apply_weight_decays, _check_args
-from .utils import _update_t_cur_eta_t_apply_lr_mult
+from .utils import _update_t_cur_eta_t_v2, _apply_lr_multiplier
 
 
 @keras_export('keras.optimizers.AdamW')
@@ -144,11 +144,10 @@ class AdamW(OptimizerV2):
         epsilon_t = ops.convert_to_tensor(self.epsilon, var_dtype)
 
         lr_t = lr_t * math_ops.sqrt(1 - beta_2_power) / (1 - beta_1_power)
-
         # Learning rate multipliers
-        # Cosine annealing
-        (iteration_done, t_cur_update, eta_t_update
-         ) = _update_t_cur_eta_t_apply_lr_mult(self, lr_t, var)
+        if self.lr_multipliers is not None:
+            lr_t = _apply_lr_multiplier(self, lr_t, var)
+
 
         m_t = state_ops.assign(m,
                                beta_1_t * m + (1.0 - beta_1_t) * grad,
@@ -171,9 +170,13 @@ class AdamW(OptimizerV2):
         if var.name in self.weight_decays.keys():
             var_t = _apply_weight_decays(self, var, var_t)
 
+        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
+
+        # Cosine annealing
+        (iteration_done, t_cur_update, eta_t_update
+         ) = _update_t_cur_eta_t_v2(self, lr_t, var)
         if iteration_done and not self._init_notified:
             self._init_notified = True
-        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
 
         updates = [var_update, m_t, v_t]
         if iteration_done:
@@ -197,11 +200,9 @@ class AdamW(OptimizerV2):
         epsilon_t = ops.convert_to_tensor(self.epsilon, var_dtype)
 
         lr_t = lr_t * math_ops.sqrt(1 - beta_2_power) / (1 - beta_1_power)
-
         # Learning rate multipliers
-        # Cosine annealing
-        (iteration_done, t_cur_update, eta_t_update
-         ) = _update_t_cur_eta_t_apply_lr_mult(self, lr_t, var)
+        if self.lr_multipliers is not None:
+            lr_t = _apply_lr_multiplier(self, lr_t, var)
 
         m_scaled_g_values = grad * (1 - beta_1_t)
         m_t = state_ops.assign(m, m * beta_1_t, use_locking=self._use_locking)
@@ -231,9 +232,13 @@ class AdamW(OptimizerV2):
         if var.name in self.weight_decays.keys():
             var_t = _apply_weight_decays(self, var, var_t)
 
+        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
+
+        # Cosine annealing
+        (iteration_done, t_cur_update, eta_t_update
+         ) = _update_t_cur_eta_t_v2(self, lr_t, var)
         if iteration_done and not self._init_notified:
             self._init_notified = True
-        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
 
         updates = [var_update, m_t, v_t]
         if iteration_done:
@@ -419,9 +424,8 @@ class NadamW(OptimizerV2):
         decay_base = math_ops.cast(0.96, var_dtype)
 
         # Learning rate multipliers
-        # Cosine annealing
-        (iteration_done, t_cur_update, eta_t_update
-         ) = _update_t_cur_eta_t_apply_lr_mult(self, lr_t, var)
+        if self.lr_multipliers is not None:
+            lr_t = _apply_lr_multiplier(self, lr_t, var)
 
         # Due to the recommendations in [2], i.e. warming momentum schedule
         momentum_cache_t = beta_1_t * (1. - 0.5 * (
@@ -454,9 +458,13 @@ class NadamW(OptimizerV2):
         if var.name in self.weight_decays.keys():
             var_t = _apply_weight_decays(self, var, var_t)
 
+        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
+
+        # Cosine annealing
+        (iteration_done, t_cur_update, eta_t_update
+         ) = _update_t_cur_eta_t_v2(self, lr_t, var)
         if iteration_done and not self._init_notified:
             self._init_notified = True
-        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
 
         updates = [var_update, m_t, v_t]
         if iteration_done:
@@ -478,9 +486,8 @@ class NadamW(OptimizerV2):
         decay_base = math_ops.cast(0.96, var_dtype)
 
         # Learning rate multipliers
-        # Cosine annealing
-        (iteration_done, t_cur_update, eta_t_update
-         ) = _update_t_cur_eta_t_apply_lr_mult(self, lr_t, var)
+        if self.lr_multipliers is not None:
+            lr_t = _apply_lr_multiplier(self, lr_t, var)
 
         momentum_cache_t = beta_1_t * (1. - 0.5 * (
             math_ops.pow(decay_base, self._initial_decay * local_step)))
@@ -523,9 +530,13 @@ class NadamW(OptimizerV2):
         if var.name in self.weight_decays.keys():
             var_t = _apply_weight_decays(self, var, var_t)
 
+        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
+
+        # Cosine annealing
+        (iteration_done, t_cur_update, eta_t_update
+         ) = _update_t_cur_eta_t_v2(self, lr_t, var)
         if iteration_done and not self._init_notified:
             self._init_notified = True
-        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
 
         updates = [var_update, m_t_bar, v_t]
         if iteration_done:
@@ -667,9 +678,8 @@ class SGDW(OptimizerV2):
         lr_t = self._decayed_lr(var_dtype)
 
         # Learning rate multipliers
-        # Cosine annealing
-        (iteration_done, t_cur_update, eta_t_update
-         ) = _update_t_cur_eta_t_apply_lr_mult(self, lr_t, var)
+        if self.lr_multipliers is not None:
+            lr_t = _apply_lr_multiplier(self, lr_t, var)
 
         if self._momentum:
             momentum = array_ops.identity(self._get_hyper('momentum', var_dtype))
@@ -690,9 +700,13 @@ class SGDW(OptimizerV2):
         if var.name in self.weight_decays.keys():
             var_t = _apply_weight_decays(self, var, var_t)
 
+        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
+
+        # Cosine annealing
+        (iteration_done, t_cur_update, eta_t_update
+         ) = _update_t_cur_eta_t_v2(self, lr_t, var)
         if iteration_done and not self._init_notified:
             self._init_notified = True
-        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
 
         updates = [var_update]
         if self._momentum:
@@ -708,9 +722,8 @@ class SGDW(OptimizerV2):
         lr_t = self._decayed_lr(var_dtype)
 
         # Learning rate multipliers
-        # Cosine annealing
-        (iteration_done, t_cur_update, eta_t_update
-         ) = _update_t_cur_eta_t_apply_lr_mult(self, lr_t, var)
+        if self.lr_multipliers is not None:
+            lr_t = _apply_lr_multiplier(self, lr_t, var)
 
         if self._momentum:
             momentum = array_ops.identity(self._get_hyper('momentum', var_dtype))
@@ -731,9 +744,13 @@ class SGDW(OptimizerV2):
         if var.name in self.weight_decays.keys():
             var_t = _apply_weight_decays(self, var, var_t)
 
+        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
+
+        # Cosine annealing
+        (iteration_done, t_cur_update, eta_t_update
+         ) = _update_t_cur_eta_t_v2(self, lr_t, var)
         if iteration_done and not self._init_notified:
             self._init_notified = True
-        var_update = state_ops.assign(var, var_t, use_locking=self._use_locking)
 
         updates = [var_update]
         if self._momentum:

--- a/keras_adamw/utils.py
+++ b/keras_adamw/utils.py
@@ -60,8 +60,8 @@ def _apply_lr_multiplier(self, lr_t, var):
             print('{} init learning rate set for {} -- {}'.format(
                '%.e' % round(lr_print, 5), var.name, lr_t))
         else:
-            print('No change in learning rate {} -- {}'.format(var.name,
-                                                               lr_print))
+            print('No change in learning rate {} -- {}'.format(
+                var.name, lr_print))
     return lr_t
 
 
@@ -75,7 +75,7 @@ def _update_t_cur_eta_t(self):  # keras
                                                  _compute_eta_t(self)))
 
 
-def _update_t_cur_eta_t_apply_lr_mult(self, lr_t=None, var=None):  # tf.keras
+def _update_t_cur_eta_t_v2(self, lr_t=None, var=None):  # tf.keras
     t_cur_update, eta_t_update = None, None  # in case not assigned
 
     # update `t_cur` if iterating last `(grad, var)`
@@ -93,9 +93,7 @@ def _update_t_cur_eta_t_apply_lr_mult(self, lr_t=None, var=None):  # tf.keras
         with ops.control_dependencies([t_cur_update]):
             eta_t_update = state_ops.assign(self.eta_t, _compute_eta_t(self),
                                             use_locking=self._use_locking)
-    # Learning rate multipliers
-    if self.lr_multipliers is not None:
-        lr_t = _apply_lr_multiplier(self, lr_t, var)
+        self.lr_t = lr_t * self.eta_t  # for external tracking
 
     return iteration_done, t_cur_update, eta_t_update
 

--- a/tests/backend.py
+++ b/tests/backend.py
@@ -4,22 +4,38 @@ import tensorflow as tf
 #### Environment configs ######################################################
 # for testing locally
 os.environ['TF_KERAS'] = os.environ.get("TF_KERAS", '1')
-os.environ['TF_EAGER'] = os.environ.get("TF_EAGER", '1')
+os.environ['TF_EAGER'] = os.environ.get("TF_EAGER", '0')
+os.environ['USE_GPU']  = os.environ.get("USE_GPU",  '0')
 
+
+#### Get flags #################################
 TF_KERAS = bool(os.environ['TF_KERAS'] == '1')
 TF_EAGER = bool(os.environ['TF_EAGER'] == '1')
 TF_2 = bool(tf.__version__[0] == '2')
+
+#### GPU/CPU config ############################
+if os.environ['USE_GPU'] == '0':
+    if TF_2:
+        tf.config.set_visible_devices([], 'GPU')
+    os.environ["CUDA_VISIBLE_DEVICES"] = '-1'
 
 if TF_2:
     USING_GPU = bool(tf.config.list_logical_devices('GPU') != [])
 else:
     USING_GPU = bool(tf.config.experimental.list_logical_devices('GPU') != [])
 
+if os.environ['USE_GPU'] == '1' and not USING_GPU:
+    raise Exception("requested to use GPU but TF failed to find it")
+elif os.environ['USE_GPU'] == '0' and USING_GPU:
+    raise Exception("requrested to use CPU, but failed to hide GPU from TF")
+
+#### Graph/Eager config ########################
 if not TF_EAGER:
     tf.compat.v1.disable_eager_execution()
 elif not TF_2:
-    raise Exception("deeptrain does not support TF1 in Eager execution")
+    raise Exception("keras-adamw does not support TF1 in Eager execution")
 
+#### Print configs #############################
 print(("{}\nTF version: {}\nTF uses {}\nTF executing in {} mode\n"
        "TF_KERAS = {}\n{}\n").format("=" * 80,
                                      tf.__version__,

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -264,11 +264,9 @@ def test_updates():
             opt = Opt(lr=1e-2, use_cosine_annealing=True, total_iterations=25)
             model = _make_model(opt, batch_shape)
             K.set_value(opt.eta_t, 0)
-            if not TF_KERAS:
-                # `keras` implem. cannot guarantee that weights are updated
-                # before eta_t is; this ensures t_cur forces eta_t to 0
-                # regardless of update order
-                K.set_value(opt.t_cur, opt.total_iterations - 2)
+            # TF cannot guarantee that weights are updated before eta_t is;
+            # this ensures t_cur forces eta_t to 0 regardless of update order
+            K.set_value(opt.t_cur, opt.total_iterations - 2)
 
             W_pre  = model.get_weights()
             model.train_on_batch(x, y)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -264,9 +264,11 @@ def test_updates():
             opt = Opt(lr=1e-2, use_cosine_annealing=True, total_iterations=25)
             model = _make_model(opt, batch_shape)
             K.set_value(opt.eta_t, 0)
-            # TF cannot guarantee that weights are updated before eta_t is;
-            # this ensures t_cur forces eta_t to 0 regardless of update order
-            K.set_value(opt.t_cur, opt.total_iterations - 2)
+            if not TF_KERAS:
+                # `keras` implem. cannot guarantee that weights are updated
+                # before eta_t is; this ensures t_cur forces eta_t to 0
+                # regardless of update order
+                K.set_value(opt.t_cur, opt.total_iterations - 2)
 
             W_pre  = model.get_weights()
             model.train_on_batch(x, y)


### PR DESCRIPTION
**BUGFIXES**:
 - Last weight in network would be updated with `t_cur` one update ahead, desynchronizing it from all other weights
 - `AdamW` in `keras` (optimizers.py, optimizers_225.py) weight updates were _not_ mediated by `eta_t`, so cosine annealing had no effect. Pardon the mishap

**FEATURES**:
 - Added `lr_t` to tf.keras optimizers to track "actual" learning rate externally; use `K.eval(model.optimizer.lr_t)` to get "actual" learning rate for given `t_cur` and `iterations`
 - Added `lr_t` vs. iterations plot to README, and source code in `example.py`

**MISC**:
 - Added `test_updates` to ensure all weights update synchronously, and that `eta_t` first applies on weights as-is and _then_ updates according to `t_cur`
 - Fixes #47 