### PR TITLE
Correct normalization scheme; deprecate `batch_size`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![](https://img.shields.io/badge/keras-tf.keras/eager-blue.svg)
 ![](https://img.shields.io/badge/keras-tf.keras/2.0-blue.svg)
 
-Keras implementation of **AdamW**, **SGDW**, **NadamW**, and **Warm Restarts**, based on paper [Decoupled Weight Decay Regularization](https://arxiv.org/abs/1711.05101) - plus **Learning Rate Multipliers**
+Keras/TF implementation of **AdamW**, **SGDW**, **NadamW**, and **Warm Restarts**, based on paper [Decoupled Weight Decay Regularization](https://arxiv.org/abs/1711.05101) - plus **Learning Rate Multipliers**
 
 <img src="https://user-images.githubusercontent.com/16495490/65381086-233f7d00-dcb7-11e9-8c83-d0aec7b3663a.png" width="850">
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ for epoch in range(3):
 ## Use guidelines
 ### Weight decay
  - **Set L2 penalty to ZERO** if regularizing a weight via `weight_decays` - else the purpose of the 'fix' is largely defeated, and weights will be over-decayed --_My recommendation_
- - `lambda = lambda_norm * sqrt(batch_size/total_iterations)` --> _can be changed_; the intent is to scale λ to _decouple_ it from other hyperparams - including (but _not limited to_), train duration & batch size. --_Authors_ (Appendix, pg.1) (A-1)
+ - `lambda = lambda_norm * sqrt(1/total_iterations)` --> _can be changed_; the intent is to scale λ to _decouple_ it from other hyperparams - including (but _not limited to_), # of epochs & batch size. --_Authors_ (Appendix, pg.1) (A-1)
  - `total_iterations_wd` --> set to normalize over _all epochs_ (or other interval `!= total_iterations`) instead of per-WR when using WR; may _sometimes_ yield better results --_My note_
 
 ### Warm restarts

--- a/example.py
+++ b/example.py
@@ -10,7 +10,7 @@ from keras_adamw import AdamW
 from keras_adamw.utils import K_eval
 
 #%%############################################################################
-ipt   = Input(shape=(120,4))
+ipt   = Input(shape=(120, 4))
 x     = LSTM(60, activation='relu', name='lstm_1',
              kernel_regularizer=l1(1e-4), recurrent_regularizer=l2(2e-4))(ipt)
 out   = Dense(1, activation='sigmoid', kernel_regularizer=l1_l2(1e-4, 2e-4))(x)

--- a/keras_adamw/__init__.py
+++ b/keras_adamw/__init__.py
@@ -28,4 +28,4 @@ else:
 from .utils import get_weight_decays, fill_dict_in_order
 from .utils import reset_seeds, K_eval
 
-__version__ = '1.35'
+__version__ = '1.36'

--- a/keras_adamw/optimizers.py
+++ b/keras_adamw/optimizers.py
@@ -30,7 +30,6 @@ class AdamW(Optimizer):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -74,7 +73,7 @@ class AdamW(Optimizer):
     """
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  amsgrad=False, model=None, zero_penalties=True,
-                 batch_size=32, total_iterations=0, total_iterations_wd=None,
+                 total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
@@ -99,7 +98,6 @@ class AdamW(Optimizer):
             self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
             self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
 
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.amsgrad = amsgrad
@@ -189,7 +187,6 @@ class AdamW(Optimizer):
             'beta_1': float(K_eval(self.beta_1)),
             'beta_2': float(K_eval(self.beta_2)),
             'decay': float(K_eval(self.decay)),
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'lr_multipliers': self.lr_multipliers,
@@ -226,7 +223,6 @@ class NadamW(Optimizer):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -271,7 +267,7 @@ class NadamW(Optimizer):
              (https://arxiv.org/abs/1711.05101)
     """
     def __init__(self, learning_rate=0.002, beta_1=0.9, beta_2=0.999,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -297,7 +293,6 @@ class NadamW(Optimizer):
             self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
             self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
 
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -388,7 +383,6 @@ class NadamW(Optimizer):
             'beta_2': float(K_eval(self.beta_2)),
             'epsilon': self.epsilon,
             'schedule_decay': self.schedule_decay,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'lr_multipliers': self.lr_multipliers,
@@ -421,7 +415,6 @@ class SGDW(Optimizer):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -465,7 +458,7 @@ class SGDW(Optimizer):
          (https://arxiv.org/abs/1711.05101)
     """
     def __init__(self, learning_rate=0.01, momentum=0., nesterov=False,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -489,7 +482,6 @@ class SGDW(Optimizer):
             self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
             self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
 
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.nesterov = nesterov
@@ -556,7 +548,6 @@ class SGDW(Optimizer):
             'momentum': float(K_eval(self.momentum)),
             'decay': float(K_eval(self.decay)),
             'nesterov': self.nesterov,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'lr_multipliers': self.lr_multipliers,

--- a/keras_adamw/optimizers_225.py
+++ b/keras_adamw/optimizers_225.py
@@ -19,7 +19,6 @@ class AdamW(Optimizer):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -63,7 +62,7 @@ class AdamW(Optimizer):
     """
     def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999, amsgrad=False,
                  epsilon=None, decay=0.0, model=None, zero_penalties=True,
-                 batch_size=32, total_iterations=0, total_iterations_wd=None,
+                 total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, **kwargs):
@@ -86,7 +85,6 @@ class AdamW(Optimizer):
 
         self.initial_decay = decay
         self.epsilon = epsilon or K.epsilon()
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.amsgrad = amsgrad
@@ -165,7 +163,6 @@ class AdamW(Optimizer):
             'beta_1': float(K.get_value(self.beta_1)),
             'beta_2': float(K.get_value(self.beta_2)),
             'decay': float(K.get_value(self.decay)),
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'lr_multipliers': self.lr_multipliers,
@@ -202,7 +199,6 @@ class NadamW(Optimizer):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -248,7 +244,7 @@ class NadamW(Optimizer):
     """
     def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999,
                  schedule_decay=0.004, epsilon=None,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -272,7 +268,6 @@ class NadamW(Optimizer):
 
         self.epsilon = epsilon or K.epsilon()
         self.schedule_decay = schedule_decay
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -352,7 +347,6 @@ class NadamW(Optimizer):
             'beta_2': float(K.get_value(self.beta_2)),
             'epsilon': self.epsilon,
             'schedule_decay': self.schedule_decay,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'lr_multipliers': self.lr_multipliers,
@@ -385,7 +379,6 @@ class SGDW(Optimizer):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -429,7 +422,7 @@ class SGDW(Optimizer):
          (https://arxiv.org/abs/1711.05101)
     """
     def __init__(self, lr=0.01, momentum=0., nesterov=False, decay=0.0,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -451,7 +444,6 @@ class SGDW(Optimizer):
             self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
 
         self.initial_decay = decay
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.nesterov = nesterov
@@ -516,7 +508,6 @@ class SGDW(Optimizer):
             'momentum': float(K.get_value(self.momentum)),
             'decay': float(K.get_value(self.decay)),
             'nesterov': self.nesterov,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'lr_multipliers': self.lr_multipliers,

--- a/keras_adamw/optimizers_225tf.py
+++ b/keras_adamw/optimizers_225tf.py
@@ -46,7 +46,6 @@ class AdamW(OptimizerV2):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -83,7 +82,7 @@ class AdamW(OptimizerV2):
     """
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=None, decay=0., amsgrad=False,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -103,7 +102,6 @@ class AdamW(OptimizerV2):
         self.eta_max = K.constant(eta_max, name='eta_max')
         self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
         self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -267,7 +265,6 @@ class AdamW(OptimizerV2):
             'beta_2': self._serialize_hyperparameter('beta_2'),
             'epsilon': self.epsilon,
             'amsgrad': self.amsgrad,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
@@ -311,7 +308,6 @@ class NadamW(OptimizerV2):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -350,7 +346,7 @@ class NadamW(OptimizerV2):
     """
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=1e-7, model=None, zero_penalties=True,
-                 batch_size=32, total_iterations=0, total_iterations_wd=None,
+                 total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
                  eta_min=0, eta_max=1, t_cur=0, name="NadamW", **kwargs):
@@ -379,7 +375,6 @@ class NadamW(OptimizerV2):
         self.eta_max = K.constant(eta_max, name='eta_max')
         self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
         self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -556,7 +551,6 @@ class NadamW(OptimizerV2):
             'beta_1': self._serialize_hyperparameter('beta_1'),
             'beta_2': self._serialize_hyperparameter('beta_2'),
             'epsilon': self.epsilon,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
@@ -594,7 +588,6 @@ class SGDW(OptimizerV2):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -631,7 +624,7 @@ class SGDW(OptimizerV2):
          (https://arxiv.org/abs/1711.05101)
     """
     def __init__(self, learning_rate=0.01, momentum=0.0, nesterov=False,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -657,7 +650,6 @@ class SGDW(OptimizerV2):
         self.eta_max = K.constant(eta_max, name='eta_max')
         self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
         self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -773,7 +765,6 @@ class SGDW(OptimizerV2):
             "decay": self._serialize_hyperparameter("decay"),
             "momentum": self._serialize_hyperparameter("momentum"),
             "nesterov": self.nesterov,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,

--- a/keras_adamw/optimizers_v2.py
+++ b/keras_adamw/optimizers_v2.py
@@ -51,7 +51,6 @@ class AdamW(OptimizerV2):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -95,7 +94,7 @@ class AdamW(OptimizerV2):
     """
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
                  epsilon=None, decay=0., amsgrad=False,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None,
@@ -116,7 +115,6 @@ class AdamW(OptimizerV2):
         self.eta_max = K.constant(eta_max, name='eta_max')
         self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
         self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -276,7 +274,6 @@ class AdamW(OptimizerV2):
             'beta_2': self._serialize_hyperparameter('beta_2'),
             'epsilon': self.epsilon,
             'amsgrad': self.amsgrad,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
@@ -320,7 +317,6 @@ class NadamW(OptimizerV2):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -365,7 +361,7 @@ class NadamW(OptimizerV2):
              (https://arxiv.org/abs/1711.05101)
     """
     def __init__(self, learning_rate=0.001, beta_1=0.9, beta_2=0.999,
-                 epsilon=1e-7, model=None, zero_penalties=True, batch_size=32,
+                 epsilon=1e-7, model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -395,7 +391,6 @@ class NadamW(OptimizerV2):
         self.eta_max = K.constant(eta_max, name='eta_max')
         self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
         self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -571,7 +566,6 @@ class NadamW(OptimizerV2):
             'beta_1': self._serialize_hyperparameter('beta_1'),
             'beta_2': self._serialize_hyperparameter('beta_2'),
             'epsilon': self.epsilon,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,
@@ -609,7 +603,6 @@ class SGDW(OptimizerV2):
             extracts weight penalties from layers, and overrides `weight_decays`.
         zero_penalties: bool. If True and `model` is passed, will zero weight
             penalties (loss-based). (RECOMMENDED; see README "Use guidelines").
-        batch_size:       int >= 1. Train input batch size; used for normalization
         total_iterations: int >= 0. Total expected iterations / weight updates
                           throughout training, used for normalization; <1>
         lr_multipliers:   dict / None. Name-value pairs specifying per-layer lr
@@ -653,7 +646,7 @@ class SGDW(OptimizerV2):
          (https://arxiv.org/abs/1711.05101)
     """
     def __init__(self, learning_rate=0.01, momentum=0.0, nesterov=False,
-                 model=None, zero_penalties=True, batch_size=32,
+                 model=None, zero_penalties=True,
                  total_iterations=0, total_iterations_wd=None,
                  use_cosine_annealing=False, lr_multipliers=None,
                  weight_decays=None, autorestart=None, init_verbose=True,
@@ -679,7 +672,6 @@ class SGDW(OptimizerV2):
         self.eta_max = K.constant(eta_max, name='eta_max')
         self.eta_t = K.variable(eta_t, dtype='float32', name='eta_t')
         self.t_cur = K.variable(t_cur, dtype='int64', name='t_cur')
-        self.batch_size = batch_size
         self.total_iterations = total_iterations
         self.total_iterations_wd = total_iterations_wd or total_iterations
         self.lr_multipliers = lr_multipliers
@@ -794,7 +786,6 @@ class SGDW(OptimizerV2):
             "decay": self._serialize_hyperparameter("decay"),
             "momentum": self._serialize_hyperparameter("momentum"),
             "nesterov": self.nesterov,
-            'batch_size': int(self.batch_size),
             'total_iterations': int(self.total_iterations),
             'weight_decays': self.weight_decays,
             'use_cosine_annealing': self.use_cosine_annealing,

--- a/keras_adamw/utils.py
+++ b/keras_adamw/utils.py
@@ -16,7 +16,7 @@ def _apply_weight_decays(self, var, var_t):
             print("Both penalties are 0 for %s, will skip" % var.name)
         return var_t
 
-    norm = math_ops.cast(math_ops.sqrt(self.batch_size / self.total_iterations_wd),
+    norm = math_ops.cast(math_ops.sqrt(1 / self.total_iterations_wd),
                          'float32')
     l1_normalized = l1 * norm
     l2_normalized = l2 * norm
@@ -30,7 +30,7 @@ def _apply_weight_decays(self, var, var_t):
     var_t = var_t - self.eta_t * decay
 
     if self.init_verbose and not self._init_notified:
-        norm_print = (self.batch_size / self.total_iterations_wd) ** (1 / 2)
+        norm_print = (1 / self.total_iterations_wd) ** (1 / 2)
         l1n_print, l2n_print = l1 * norm_print, l2 * norm_print
         decays_str = "{}(L1), {}(L2)".format(l1n_print, l2n_print)
         print('{} weight decay set for {}'.format(decays_str, var.name))

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -183,7 +183,7 @@ def _test_control(optimizer_name, amsgrad=False, nesterov=False, momentum=.9):
     reset_seeds(reset_graph_with_backend=K, verbose=0)
     model_custom = _make_model(**model_kw)
     optimizer_custom = _make_optimizer(optimizer_name, model_custom,
-                                        **optimizer_kw)
+                                       **optimizer_kw)
     model_custom.compile(optimizer_custom, loss=loss_name)
     loss_custom = []  # for introspection
     t0 = time()


### PR DESCRIPTION
Existing code normalized as: `norm = sqrt(batch_size / total_iterations)`, where `total_iterations` = (number of fits per epoch) * (number of epochs in restart). However, `total_iterations = total_samples / batch_size` --> `norm = batch_size * sqrt(1 / (total_iterations_per_epoch * epochs))`, making `norm` scale _linearly_ with `batch_size`, which differs from authors' sqrt.

Users who never changed `batch_size` throughout training will be unaffected. (λ = λ_norm * sqrt(b / BT); λ_norm is what we pick, our "guess". The idea of normalization is to make it so that if our guess works well for `batch_size=32`, it'll work well for `batch_size=16` - but if `batch_size` is never changed, then performance is only affected by the guess.)

Main change [here](https://github.com/OverLordGoldDragon/keras-adamw/pull/53/files#diff-220519926b87c12115d2f727803fbe6bR19), closing #52.

**Updating existing code**: for a choice of λ_norm that previously worked well, apply `*=  sqrt(batch_size)`. Ex: `Dense(bias_regularizer=l2(1e-4))` --> `Dense(bias_regularizer=l2(1e-4 * sqrt(32)))`.
